### PR TITLE
Update MindtPy documentation links

### DIFF
--- a/6-software.md
+++ b/6-software.md
@@ -30,7 +30,7 @@ banner_color: style4
    <li>Feasibility Pump (FP)</li>
   </ul>
   <ul class="actions">
-   <li><a href="https://pyomo.readthedocs.io/en/stable/contributed_packages/mindtpy.html" class="button next" target="_blank">Get Started</a></li>
+   <li><a href="https://pyomo.readthedocs.io/en/stable/explanation/solvers/mindtpy.html" class="button next" target="_blank">Get Started</a></li>
   </ul>
  </div>
 </section>

--- a/_posts/2023-07-01-MindtPy.md
+++ b/_posts/2023-07-01-MindtPy.md
@@ -5,7 +5,7 @@ description: 'The MindtPy abstract accepted'
 image: assets/images/posts/Speaker_2023_INFORMS_Annual_Meeting_Graphic.webp
 ---
 
-The abstract of [MindtPy](https://pyomo.readthedocs.io/en/stable/contributed_packages/mindtpy.html) has been accepted to both [2023 AIChE Annual Meeting](https://www.aiche.org/conferences/aiche-annual-meeting/2023?gclid=Cj0KCQjwrMKmBhCJARIsAHuEAPR5h2LVn51eow9v9Vkcsy4C0goZVonySZxvBWmeif5ffqKY29GgfOYaAnNmEALw_wcB) and [2023 INFORMS Annual Meeting](https://meetings.informs.org/wordpress/phoenix2023/).
+The abstract of [MindtPy](https://pyomo.readthedocs.io/en/stable/explanation/solvers/mindtpy.html) has been accepted to both [2023 AIChE Annual Meeting](https://www.aiche.org/conferences/aiche-annual-meeting/2023?gclid=Cj0KCQjwrMKmBhCJARIsAHuEAPR5h2LVn51eow9v9Vkcsy4C0goZVonySZxvBWmeif5ffqKY29GgfOYaAnNmEALw_wcB) and [2023 INFORMS Annual Meeting](https://meetings.informs.org/wordpress/phoenix2023/).
 
 ![AIChE 2023]({% link assets/images/posts/AIChE2023.webp %}){: .center-image }
 

--- a/_posts/2023-08-01-Zedong.md
+++ b/_posts/2023-08-01-Zedong.md
@@ -5,7 +5,7 @@ description: 'The first postdoc in our group'
 image: assets/images/posts/Zedong_Albert.webp
 ---
 
-[Zedong Peng](https://SECQUOIA.github.io/2-members.html) obtained his Ph.D. from Zhejiang University in 2021, co-advised by Prof. Gang Rong and Prof. Hongye Su. During his Ph.D., he visited the Grossmann Research Group at Carnegie Mellon University in 2018. In addition, Zedong is also the main developer of [MindtPy](https://pyomo.readthedocs.io/en/stable/contributed_packages/mindtpy.html). We are delighted to have Zedong join our group, and he will work on algorithms and software for Mixed-Integer Nonlinear Programming. Zedong will pursue an academic or research position after the postdoc.
+[Zedong Peng](https://SECQUOIA.github.io/2-members.html) obtained his Ph.D. from Zhejiang University in 2021, co-advised by Prof. Gang Rong and Prof. Hongye Su. During his Ph.D., he visited the Grossmann Research Group at Carnegie Mellon University in 2018. In addition, Zedong is also the main developer of [MindtPy](https://pyomo.readthedocs.io/en/stable/explanation/solvers/mindtpy.html). We are delighted to have Zedong join our group, and he will work on algorithms and software for Mixed-Integer Nonlinear Programming. Zedong will pursue an academic or research position after the postdoc.
 
 ![Zedong Albert]({% link assets/images/posts/Zedong_Albert.webp %}){: style="display: block; margin-left: auto; margin-right: auto; width: 50%;" }
 

--- a/_posts/2023-10-18-INFORMS.md
+++ b/_posts/2023-10-18-INFORMS.md
@@ -6,7 +6,7 @@ image: assets/images/posts/INFORMS-2023-David-Zedong.webp
 ---
 We wrapped up our first INFORMS annual meeting.
 
-- [Zedong Peng](https://SECQUOIA.github.io/2-members.html) presented the work on open-source discrete nonlinear optimizer [**MindtPy**](https://pyomo.readthedocs.io/en/stable/contributed_packages/mindtpy.html).
+- [Zedong Peng](https://SECQUOIA.github.io/2-members.html) presented the work on open-source discrete nonlinear optimizer [**MindtPy**](https://pyomo.readthedocs.io/en/stable/explanation/solvers/mindtpy.html).
 - [David Esteban Bernal Neira](https://SECQUOIA.github.io/1-bernalde.html) chaired the session on **hybrid classical quantum algorithms for optimization** and presented as well about quantum and physics-inspired methods for constrained optimization.
 
 For many more to come!


### PR DESCRIPTION
Correct links to the MindtPy documentation throughout the site to ensure users access the appropriate resources.
Wrong link was found in #10

