### PR TITLE
Fix homepage invalid block-in-paragraph markup

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -36,7 +36,7 @@
                 <header class="major">
                     <h2>Who are we?</h2>
                 </header>
-                <p>{{ content }}</p>
+                {{ content }}
                 <!-- <ul class="actions">
                     <li><a href="#launch" class="button next">Learn More</a></li>
                 </ul> -->


### PR DESCRIPTION
## Summary
- remove paragraph wrapper around `{{ content }}` in the home layout
- keep homepage section content as block-level HTML

## Why
`index.md` contains `<section>` blocks; wrapping all content in `<p>` created invalid HTML.

Closes #145
