### PR TITLE
Fix members page section/container structure

### DIFF
--- a/2-members.md
+++ b/2-members.md
@@ -100,9 +100,6 @@ banner_color: style2
 }
 </style>
 
-<!-- Main -->
-<div id="main">
-
 <div class="toc">
   <h4>Jump to Section</h4>
   <ul>
@@ -819,10 +816,12 @@ banner_color: style2
       <li style="margin-bottom: 10px;">2024. Abigail Delaney. Imperial College London, MSc Student in AI and Machine Learning.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
       <li style="display: inline;"><a href="https://www.linkedin.com/in/abby-delaney-693b4321a/" class="fab fa-linkedin" aria-label="Abigail Delaney LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/abdelane" class="fab fa-github" aria-label="Abigail Delaney GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      </ul>
-      </li>
-      </ul>
+	      <li style="display: inline;"><a href="https://github.com/abdelane" class="fab fa-github" aria-label="Abigail Delaney GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+	      </ul>
+	      </li>
+	      </ul>
+ </div>
+</section>
 
 <section id="map" class="spotlights">
   <div class="inner">

--- a/2-members.md
+++ b/2-members.md
@@ -816,10 +816,10 @@ banner_color: style2
       <li style="margin-bottom: 10px;">2024. Abigail Delaney. Imperial College London, MSc Student in AI and Machine Learning.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
       <li style="display: inline;"><a href="https://www.linkedin.com/in/abby-delaney-693b4321a/" class="fab fa-linkedin" aria-label="Abigail Delaney LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-	      <li style="display: inline;"><a href="https://github.com/abdelane" class="fab fa-github" aria-label="Abigail Delaney GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-	      </ul>
-	      </li>
-	      </ul>
+      <li style="display: inline;"><a href="https://github.com/abdelane" class="fab fa-github" aria-label="Abigail Delaney GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      </ul>
+      </li>
+      </ul>
  </div>
 </section>
 


### PR DESCRIPTION
## Summary
- remove nested `#main` wrapper from `2-members.md` (owned by page layout)
- explicitly close Alumni section containers before the map section

## Why
This fixes brittle section/container nesting and keeps page structure aligned with `_layouts/page.html`.

Closes #146
