### PR TITLE
Fix robots.txt sitemap declaration

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: {{ site.url }}/sitemap.xml
+Sitemap: https://SECQUOIA.github.io/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,8 @@
+---
+layout: null
+---
+
 User-agent: *
 Allow: /
 
-Sitemap: https://SECQUOIA.github.io/sitemap.xml
+Sitemap: {{ "/sitemap.xml" | absolute_url }}


### PR DESCRIPTION
## Summary
- replace Liquid placeholder in `robots.txt` with explicit absolute sitemap URL

## Why
`robots.txt` is plain text and can ship with unresolved Liquid placeholders if not processed.

Closes #147
