### PR TITLE
Harden target=_blank links with rel noopener noreferrer

### DIFF
--- a/1-bernalde.md
+++ b/1-bernalde.md
@@ -51,7 +51,7 @@ h2 {
     David E. Bernal Neira is an Assistant Professor in the Davidson School of Chemical Engineering at Purdue University. His research centers on mathematical optimization, artificial intelligence, and computational methods for solving scientific and engineering problems, with applications in process systems, energy, and chemical engineering. His core expertise is in nonlinear discrete optimization, encompassing theory, algorithms, and software. He also leads research in quantum computing, with emphasis on quantum algorithms for optimization, computational chemistry, and machine learning. He has co-authored peer-reviewed publications, developed open-source tools, and delivered invited talks across academia, government, and industry. He has taught several courses, including one he co-designed on optimization, quantum computing, and machine learning. He collaborates broadly with researchers in academia, national laboratories, government agencies, and industry. At Purdue, he leads the <a href="index.html">SECQUOIA</a> lab (Systems Engineering via Classical and QUantum Optimization for Industrial Applications).
     </p>
 
-    <p><a href="https://engineering.purdue.edu/ChE/people/ptProfile?resource_id=286478" target="_blank">Link to his profile</a> at Purdue University.</p>
+    <p><a href="https://engineering.purdue.edu/ChE/people/ptProfile?resource_id=286478" target="_blank" rel="noopener noreferrer">Link to his profile</a> at Purdue University.</p>
 
     <ul>
       <li><a href="files/cv.html">Full CV</a></li>
@@ -109,8 +109,8 @@ h2 {
   <ul>
     <li>Process Dynamics and Control — Purdue CHE456 (Fall 2023, Fall 2024)</li>
     <li>Quantum Integer Programming and Machine Learning — CMU 47-779 / 47-785, 18-819F<br>
-      <a href="https://bernalde.github.io/QuIPML/" target="_blank">Fall 2021</a>, <a href="https://bernalde.github.io/QuIPML22/" target="_blank">Fall 2022</a>, Fall 2023, Fall 2024</li>
-    <li>Quantum Integer Programming — CMU 47-779 <a href="https://bernalde.github.io/QuIP/" target="_blank">Fall 2020</a></li>
+      <a href="https://bernalde.github.io/QuIPML/" target="_blank" rel="noopener noreferrer">Fall 2021</a>, <a href="https://bernalde.github.io/QuIPML22/" target="_blank" rel="noopener noreferrer">Fall 2022</a>, Fall 2023, Fall 2024</li>
+    <li>Quantum Integer Programming — CMU 47-779 <a href="https://bernalde.github.io/QuIP/" target="_blank" rel="noopener noreferrer">Fall 2020</a></li>
   </ul>
 
   <h2>Awards</h2>

--- a/2-members.md
+++ b/2-members.md
@@ -460,7 +460,7 @@ banner_color: style2
     <ul class="icons">
       <li><a href="https://github.com/Toflamus" class="fab fa-github" aria-label="Chaolong Wang's GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       <li><a href="https://www.linkedin.com/in/chaolong-wang-526a412a1/" class="fab fa-linkedin" aria-label="Chaolong Wang's LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://orcid.org/0009-0006-8705-861X" class="fab fa-orcid" aria-label="Anja Hribljan ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
+      <li><a href="https://orcid.org/0009-0006-8705-861X" class="fab fa-orcid" aria-label="Chaolong Wang's ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
     </ul>
    </div>
   </div>

--- a/2-members.md
+++ b/2-members.md
@@ -141,9 +141,9 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Combinatorial Optimization, Graph Theory and Quantum Machine Learning.</p>
     <ul class="icons">
-      <li><a href="https://linkedin.com/in/hanjing-xu-097615b6/" class="fab fa-linkedin" aria-label="Hanjing Xu LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/jxsoortha" class="fab fa-github" aria-label="Hanjing Xu GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li><a href="https://orcid.org/0000-0002-8118-0570" class="fab fa-orcid" aria-label="Hanjing Xu ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li><a href="https://linkedin.com/in/hanjing-xu-097615b6/" class="fab fa-linkedin" aria-label="Hanjing Xu LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/jxsoortha" class="fab fa-github" aria-label="Hanjing Xu GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li><a href="https://orcid.org/0000-0002-8118-0570" class="fab fa-orcid" aria-label="Hanjing Xu ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
     </ul>
    </div>
   </div>
@@ -200,9 +200,9 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Superstructure Optimization, Generalized Disjunctive Programming.</p>
     <ul class="icons">
-      <li><a href="https://www.linkedin.com/in/albert-lee-45570a24b/" class="fab fa-linkedin" aria-label="Albert Lee LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/AlbertLee125" class="fab fa-github" aria-label="Albert Lee GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li><a href="https://orcid.org/0000-0002-4474-3266" class="fab fa-orcid" aria-label="Albert Lee ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li><a href="https://www.linkedin.com/in/albert-lee-45570a24b/" class="fab fa-linkedin" aria-label="Albert Lee LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/AlbertLee125" class="fab fa-github" aria-label="Albert Lee GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li><a href="https://orcid.org/0000-0002-4474-3266" class="fab fa-orcid" aria-label="Albert Lee ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
     </ul>
    </div>
   </div>
@@ -226,9 +226,9 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Benchmarking Classical and Quantum Algorithms for Optimization and Computational Chemistry.</p>
     <ul class="icons">
-      <li><a href="https://www.linkedin.com/in/anuragr20" class="fab fa-linkedin" aria-label="Anurag Ramesh LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/anurag-r20" class="fab fa-github" aria-label="Anurag Ramesh GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li><a href="https://orcid.org/0009-0001-8360-8614" class="fab fa-orcid" aria-label="Anurag Ramesh ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li><a href="https://www.linkedin.com/in/anuragr20" class="fab fa-linkedin" aria-label="Anurag Ramesh LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/anurag-r20" class="fab fa-github" aria-label="Anurag Ramesh GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li><a href="https://orcid.org/0009-0001-8360-8614" class="fab fa-orcid" aria-label="Anurag Ramesh ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
     </ul>
    </div>
   </div>
@@ -253,9 +253,9 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Pharmaceutical Process Synthesis and Optimization.</p>
     <ul class="icons">
-      <li><a href="https://www.linkedin.com/in/yirangp/" class="fab fa-linkedin" aria-label="Yirang Park LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/parkyr" class="fab fa-github" aria-label="Yirang Park GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li><a href="https://orcid.org/0009-0008-6629-3308" class="fab fa-orcid" aria-label="Yirang Park ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li><a href="https://www.linkedin.com/in/yirangp/" class="fab fa-linkedin" aria-label="Yirang Park LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/parkyr" class="fab fa-github" aria-label="Yirang Park GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li><a href="https://orcid.org/0009-0008-6629-3308" class="fab fa-orcid" aria-label="Yirang Park ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
     </ul>
    </div>
   </div>
@@ -280,9 +280,9 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Hybrid Quantum Algorithms for Structured Optimization Problems in Process Systems Engineering.</p>
     <ul class="icons">
-      <li><a href="https://www.linkedin.com/in/sergey-gusev-0b7770150/" class="fab fa-linkedin" aria-label="Sergey Gusev LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/sergey-gusev94" class="fab fa-github" aria-label="Sergey Gusev GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li><a href="https://orcid.org/0009-0004-1639-4048" class="fab fa-orcid" aria-label="Sergey Gusev ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li><a href="https://www.linkedin.com/in/sergey-gusev-0b7770150/" class="fab fa-linkedin" aria-label="Sergey Gusev LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/sergey-gusev94" class="fab fa-github" aria-label="Sergey Gusev GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li><a href="https://orcid.org/0009-0004-1639-4048" class="fab fa-orcid" aria-label="Sergey Gusev ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
     </ul>
    </div>
   </div>
@@ -307,9 +307,9 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Optimization-aided process synthesis and operations</p>
     <ul class="icons">
-      <li><a href="https://www.linkedin.com/in/andres-f-cabeza-2075a3149/" class="fab fa-linkedin" aria-label="Andres F. Cabeza LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/andres9403" class="fab fa-github" aria-label="Andres F. Cabeza GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li><a href="https://orcid.org/0009-0008-5932-564X" class="fab fa-orcid" aria-label="Andres F. Cabeza ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li><a href="https://www.linkedin.com/in/andres-f-cabeza-2075a3149/" class="fab fa-linkedin" aria-label="Andres F. Cabeza LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/andres9403" class="fab fa-github" aria-label="Andres F. Cabeza GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li><a href="https://orcid.org/0009-0008-5932-564X" class="fab fa-orcid" aria-label="Andres F. Cabeza ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
     </ul>
    </div>
   </div>
@@ -334,9 +334,9 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Quantum Physics Informed Neural Networks</p>
     <ul class="icons">
-     <li><a href="https://www.linkedin.com/in/hribljan-anja/" class="fab fa-linkedin" aria-label="Anja Hribljan LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-     <li><a href="https://github.com/ahribljan" class="fab fa-github" aria-label="Anja Hribljan GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-     <li><a href="https://orcid.org/0009-0001-2852-1487" class="fab fa-orcid" aria-label="Anja Hribljan ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+     <li><a href="https://www.linkedin.com/in/hribljan-anja/" class="fab fa-linkedin" aria-label="Anja Hribljan LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+     <li><a href="https://github.com/ahribljan" class="fab fa-github" aria-label="Anja Hribljan GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+     <li><a href="https://orcid.org/0009-0001-2852-1487" class="fab fa-orcid" aria-label="Anja Hribljan ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
     </ul>
    </div>
   </div>
@@ -361,9 +361,9 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Data-Driven Enhanced Oil Recovery.</p>
     <ul class="icons">
-      <li><a href="https://www.linkedin.com/in/mohamed-mazhar-laljee/" class="fab fa-linkedin" aria-label="Mohamed Mazhar Laljee LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/Mazhar331" class="fab fa-github" aria-label="Mohamed Mazhar Laljee GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li><a href="https://orcid.org/0009-0000-1665-7777" class="fab fa-orcid" aria-label="Mohamed Mazhar Laljee ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li><a href="https://www.linkedin.com/in/mohamed-mazhar-laljee/" class="fab fa-linkedin" aria-label="Mohamed Mazhar Laljee LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/Mazhar331" class="fab fa-github" aria-label="Mohamed Mazhar Laljee GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li><a href="https://orcid.org/0009-0000-1665-7777" class="fab fa-orcid" aria-label="Mohamed Mazhar Laljee ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
     </ul>
    </div>
   </div>
@@ -397,8 +397,8 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Quantum Optimization.</p>
     <ul class="icons">
-      <li><a href="https://www.linkedin.com/in/kimwoosik/" class="fab fa-linkedin" aria-label="Woosik Kim LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/peterkim01" class="fab fa-github" aria-label="Woosik Kim GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li><a href="https://www.linkedin.com/in/kimwoosik/" class="fab fa-linkedin" aria-label="Woosik Kim LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/peterkim01" class="fab fa-github" aria-label="Woosik Kim GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
     </ul>
    </div>
   </div>
@@ -432,8 +432,8 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Machine Learning, Quantum Computing, Optimization</p>
     <ul class="icons">
-      <li><a href="https://github.com/jvpcms" class="fab fa-github" aria-label="João Victor's GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li><a href="https://www.linkedin.com/in/jo%C3%A3ovictor-engenharia/" class="fab fa-linkedin" aria-label="João Victor's LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/jvpcms" class="fab fa-github" aria-label="João Victor's GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li><a href="https://www.linkedin.com/in/jo%C3%A3ovictor-engenharia/" class="fab fa-linkedin" aria-label="João Victor's LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
     </ul>
    </div>
   </div>
@@ -458,9 +458,9 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Process Superstructures</p>
     <ul class="icons">
-      <li><a href="https://github.com/Toflamus" class="fab fa-github" aria-label="Chaolong Wang's GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li><a href="https://www.linkedin.com/in/chaolong-wang-526a412a1/" class="fab fa-linkedin" aria-label="Chaolong Wang's LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://orcid.org/0009-0006-8705-861X" class="fab fa-orcid" aria-label="Anja Hribljan ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li><a href="https://github.com/Toflamus" class="fab fa-github" aria-label="Chaolong Wang's GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li><a href="https://www.linkedin.com/in/chaolong-wang-526a412a1/" class="fab fa-linkedin" aria-label="Chaolong Wang's LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://orcid.org/0009-0006-8705-861X" class="fab fa-orcid" aria-label="Anja Hribljan ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
     </ul>
    </div>
   </div>
@@ -493,8 +493,8 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Process Systems Machine Learning.</p>
     <ul class="icons">
-      <li><a href="https://www.linkedin.com/in/akshay-mahajan-b01122232/" class="fab fa-linkedin" aria-label="Akshay Mahajan LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/akrmahajan" class="fab fa-github" aria-label="Akshay Mahajan GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li><a href="https://www.linkedin.com/in/akshay-mahajan-b01122232/" class="fab fa-linkedin" aria-label="Akshay Mahajan LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/akrmahajan" class="fab fa-github" aria-label="Akshay Mahajan GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
     </ul>
    </div>
   </div>
@@ -518,8 +518,8 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Pharmaceutical Process Synthesis and Optimization.</p>
     <ul class="icons">
-      <li><a href="https://www.linkedin.com/in/saivisvesh-karthik/" class="fab fa-linkedin" aria-label="Sai Karthik LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/sa1K" class="fab fa-github" aria-label="Sai Karthik GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li><a href="https://www.linkedin.com/in/saivisvesh-karthik/" class="fab fa-linkedin" aria-label="Sai Karthik LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/sa1K" class="fab fa-github" aria-label="Sai Karthik GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
     </ul>
    </div>
   </div>
@@ -543,8 +543,8 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Quantum Federated Learning for Biomedical Applications.</p>
     <ul class="icons">
-      <li><a href="https://www.linkedin.com/in/alan-s-yi/" class="fab fa-linkedin" aria-label="Alan Yi LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/ailunyi" class="fab fa-github" aria-label="Alan Yi GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li><a href="https://www.linkedin.com/in/alan-s-yi/" class="fab fa-linkedin" aria-label="Alan Yi LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/ailunyi" class="fab fa-github" aria-label="Alan Yi GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
     </ul>
    </div>
   </div>
@@ -568,9 +568,9 @@ banner_color: style2
     </ul>
     <p><b>Research topics</b>: Quantum Integer Programming and Machine Learning</p>
     <ul class="icons">
-      <li><a href="https://www.linkedin.com/in/azainkhalid/" class="fab fa-linkedin" aria-label="Azain Khalid LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/AzAINN" class="fab fa-github" aria-label="Azain Khalid GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li><a href="https://orcid.org/0009-0005-4801-6452" class="fab fa-orcid" aria-label="Azain Khalid ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li><a href="https://www.linkedin.com/in/azainkhalid/" class="fab fa-linkedin" aria-label="Azain Khalid LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/AzAINN" class="fab fa-github" aria-label="Azain Khalid GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li><a href="https://orcid.org/0009-0005-4801-6452" class="fab fa-orcid" aria-label="Azain Khalid ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
     </ul>
    </div>
   </div>
@@ -597,7 +597,7 @@ banner_color: style2
             <a href="https://www.linkedin.com/in/soumen-pradhan-0a3ab6242/"
                class="fab fa-linkedin"
                aria-label="Soumen Pradhan LinkedIn Profile"
-               target="_blank">
+               target="_blank" rel="noopener noreferrer">
               <span class="label">LinkedIn</span>
             </a>
           </li>
@@ -605,7 +605,7 @@ banner_color: style2
             <a href="https://github.com/pradshaan"
                class="fab fa-github"
                aria-label="Soumen Pradhan GitHub Profile"
-               target="_blank">
+               target="_blank" rel="noopener noreferrer">
               <span class="label">GitHub</span>
             </a>
           </li>
@@ -636,7 +636,7 @@ banner_color: style2
             <a href="https://www.linkedin.com/in/tarik-guler-19374b2a6/"
                class="fab fa-linkedin"
                aria-label="Tarik Guler LinkedIn Profile"
-               target="_blank">
+               target="_blank" rel="noopener noreferrer">
               <span class="label">LinkedIn</span>
             </a>
           </li>
@@ -644,7 +644,7 @@ banner_color: style2
             <a href="https://github.com/tarikLG"
                class="fab fa-github"
                aria-label="Tarik Guler GitHub Profile"
-               target="_blank">
+               target="_blank" rel="noopener noreferrer">
               <span class="label">GitHub</span>
             </a>
           </li>
@@ -679,9 +679,9 @@ banner_color: style2
       <li><a href="1-bernalde.html">Main information</a>.</li>
     </ul>
     <ul class="icons">
-      <li><a href="https://www.linkedin.com/in/bernalde/" class="fab fa-linkedin" aria-label="David E. Bernal Neira LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li><a href="https://github.com/bernalde" class="fab fa-github" aria-label="David E. Bernal Neira GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li><a href="https://orcid.org/0000-0002-8308-5016" class="fab fa-orcid" aria-label="David E. Bernal Neira ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li><a href="https://www.linkedin.com/in/bernalde/" class="fab fa-linkedin" aria-label="David E. Bernal Neira LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li><a href="https://github.com/bernalde" class="fab fa-github" aria-label="David E. Bernal Neira GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li><a href="https://orcid.org/0000-0002-8308-5016" class="fab fa-orcid" aria-label="David E. Bernal Neira ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
     </ul>
    </div>
   </div>
@@ -698,29 +698,29 @@ banner_color: style2
        <ul class="alumni-list" style="margin: 0; padding-left: 1.5em; list-style: disc;">
       <li style="margin-bottom: 10px;">2025. Carolina Tristan. KeyLogic at the National Energy Technology Laboratory (NETL).
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/carolina-trist%C3%A1n-teja-3533582b4/" class="fab fa-linkedin" aria-label="Carolina Tristan LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/tristantc" class="fab fa-github" aria-label="Carolina Tristan GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li style="display: inline;"><a href="https://orcid.org/0000-0002-6381-5958" class="fab fa-orcid" aria-label="Carolina Tristan ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/carolina-trist%C3%A1n-teja-3533582b4/" class="fab fa-linkedin" aria-label="Carolina Tristan LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/tristantc" class="fab fa-github" aria-label="Carolina Tristan GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://orcid.org/0000-0002-6381-5958" class="fab fa-orcid" aria-label="Carolina Tristan ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2025. Hamta Bardool.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/hamta-bardool-6ba418116/" class="fab fa-linkedin" aria-label="Hamta Bardool LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/Hamtabardool" class="fab fa-github" aria-label="Hamta Bardool GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li style="display: inline;"><a href="https://orcid.org/0000-0002-6834-4913" class="fab fa-orcid" aria-label="Hamta Bardool ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/hamta-bardool-6ba418116/" class="fab fa-linkedin" aria-label="Hamta Bardool LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/Hamtabardool" class="fab fa-github" aria-label="Hamta Bardool GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://orcid.org/0000-0002-6834-4913" class="fab fa-orcid" aria-label="Hamta Bardool ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2024. Zedong Peng. Massachusetts Institute of Technology (MIT).
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/zedong-peng-1a97b0118/" class="fab fa-linkedin" aria-label="Zedong Peng LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/ZedongPeng" class="fab fa-github" aria-label="Zedong Peng GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li style="display: inline;"><a href="https://orcid.org/0000-0001-6001-1738" class="fab fa-orcid" aria-label="Zedong Peng ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/zedong-peng-1a97b0118/" class="fab fa-linkedin" aria-label="Zedong Peng LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/ZedongPeng" class="fab fa-github" aria-label="Zedong Peng GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://orcid.org/0000-0001-6001-1738" class="fab fa-orcid" aria-label="Zedong Peng ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2024. Amandeep Singh Bhatia. North Carolina State University.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/amandeep-singh-bhatia-phd-07b83822/" class="fab fa-linkedin" aria-label="Amandeep Singh Bhatia LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/deepquantum88" class="fab fa-github" aria-label="Amandeep Singh Bhatia GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/amandeep-singh-bhatia-phd-07b83822/" class="fab fa-linkedin" aria-label="Amandeep Singh Bhatia LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/deepquantum88" class="fab fa-github" aria-label="Amandeep Singh Bhatia GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       </ul>
       </li>
       </ul>
@@ -728,47 +728,47 @@ banner_color: style2
       <ul class="alumni-list" style="margin: 0; padding-left: 1.5em; list-style: disc;">
       <li style="margin-bottom: 10px;">2025. Mateo Huertas Marulanda. National University of Colombia.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/mhuertasm/" class="fab fa-linkedin" aria-label="Mateo Huertas Marulanda LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/mhuertasm" class="fab fa-github" aria-label="Mateo Huertas Marulanda GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/mhuertasm/" class="fab fa-linkedin" aria-label="Mateo Huertas Marulanda LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/mhuertasm" class="fab fa-github" aria-label="Mateo Huertas Marulanda GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2025. Daniel Anoruo. Towson University.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/danano/" class="fab fa-linkedin" aria-label="Daniel Anoruo LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/danoruo1" class="fab fa-github" aria-label="Daniel Anoruo GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/danano/" class="fab fa-linkedin" aria-label="Daniel Anoruo LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/danoruo1" class="fab fa-github" aria-label="Daniel Anoruo GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2024. Andres F. Cabeza. Purdue University, PhD Student Chemical Engineering.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/andres-f-cabeza-2075a3149/" class="fab fa-linkedin" aria-label="Andres F. Cabeza LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/andres9403" class="fab fa-github" aria-label="Andres F. Cabeza GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li style="display: inline;"><a href="https://orcid.org/0009-0008-5932-564X" class="fab fa-orcid" aria-label="Andres F. Cabeza ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/andres-f-cabeza-2075a3149/" class="fab fa-linkedin" aria-label="Andres F. Cabeza LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/andres9403" class="fab fa-github" aria-label="Andres F. Cabeza GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://orcid.org/0009-0008-5932-564X" class="fab fa-orcid" aria-label="Andres F. Cabeza ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2024. Iago Leal de Freitas. Federal University of Rio de Janeiro.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/iagolealf/" class="fab fa-linkedin" aria-label="Iago Leal de Freitas LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/iagoleal" class="fab fa-github" aria-label="Iago Leal de Freitas GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li style="display: inline;"><a href="https://orcid.org/0009-0001-6813-5863" class="fab fa-orcid" aria-label="Iago Leal de Freitas ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/iagolealf/" class="fab fa-linkedin" aria-label="Iago Leal de Freitas LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/iagoleal" class="fab fa-github" aria-label="Iago Leal de Freitas GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://orcid.org/0009-0001-6813-5863" class="fab fa-orcid" aria-label="Iago Leal de Freitas ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2024. André Lima Alambert. University of São Paulo.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/andr%C3%A9-lima-alambert-301078292/" class="fab fa-linkedin" aria-label="André Lima Alambert LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/alimaala2002" class="fab fa-github" aria-label="André Lima Alambert GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/andr%C3%A9-lima-alambert-301078292/" class="fab fa-linkedin" aria-label="André Lima Alambert LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/alimaala2002" class="fab fa-github" aria-label="André Lima Alambert GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2024. Juan S. Rodríguez F. AgroParisTech Université Paris-Saclay.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://github.com/jsrodriguezf" class="fab fa-github" aria-label="Juan S. Rodríguez F. GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li style="display: inline;"><a href="https://orcid.org/0000-0001-7348-3857" class="fab fa-orcid" aria-label="Juan S. Rodríguez F. ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/jsrodriguezf" class="fab fa-github" aria-label="Juan S. Rodríguez F. GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://orcid.org/0000-0001-7348-3857" class="fab fa-orcid" aria-label="Juan S. Rodríguez F. ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2023. Pedro Maciel Xavier. Purdue University, PhD Student Electrical and Computer Engineering.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/pedro-maciel-xavier/" class="fab fa-linkedin" aria-label="Pedro Maciel Xavier LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/pedromxavier" class="fab fa-github" aria-label="Pedro Maciel Xavier GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
-      <li style="display: inline;"><a href="https://orcid.org/0000-0002-4678-4942" class="fab fa-orcid" aria-label="Pedro Maciel Xavier ORCID Profile" target="_blank"><span class="label">ORCID</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/pedro-maciel-xavier/" class="fab fa-linkedin" aria-label="Pedro Maciel Xavier LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/pedromxavier" class="fab fa-github" aria-label="Pedro Maciel Xavier GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://orcid.org/0000-0002-4678-4942" class="fab fa-orcid" aria-label="Pedro Maciel Xavier ORCID Profile" target="_blank" rel="noopener noreferrer"><span class="label">ORCID</span></a></li>
       </ul>
       </li>
       </ul>
@@ -776,50 +776,50 @@ banner_color: style2
       <ul class="alumni-list" style="margin: 0; padding-left: 1.5em; list-style: disc;">
       <li style="margin-bottom: 10px;">2025. Alexander (AJ) Collins. Purdue University.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/alexandercollins3/" class="fab fa-linkedin" aria-label="Alexander Collins LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/colli525" class="fab fa-github" aria-label="Alexander Collins GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/alexandercollins3/" class="fab fa-linkedin" aria-label="Alexander Collins LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/colli525" class="fab fa-github" aria-label="Alexander Collins GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2025. Ben Murray. Applied Materials.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/murraybj/" class="fab fa-linkedin" aria-label="Ben Murray LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/murraybj" class="fab fa-github" aria-label="Ben Murray GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/murraybj/" class="fab fa-linkedin" aria-label="Ben Murray LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/murraybj" class="fab fa-github" aria-label="Ben Murray GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2024. Sergio Barrios. Imperial College London, MSc Student in Management.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/sergio-barrios-rosado/" class="fab fa-linkedin" aria-label="Sergio Barrios LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/barrios2001" class="fab fa-github" aria-label="Sergio Barrios GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/sergio-barrios-rosado/" class="fab fa-linkedin" aria-label="Sergio Barrios LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/barrios2001" class="fab fa-github" aria-label="Sergio Barrios GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2024. Dhruv Mendpara. Apex Healthcare USA Inc.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/dhruv-mendpara-594875237/" class="fab fa-linkedin" aria-label="Dhruv Mendpara LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/dhruvmendpara1" class="fab fa-github" aria-label="Dhruv Mendpara GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/dhruv-mendpara-594875237/" class="fab fa-linkedin" aria-label="Dhruv Mendpara LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/dhruvmendpara1" class="fab fa-github" aria-label="Dhruv Mendpara GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2024. Lukas Peng. Purdue University.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/lukas-peng/" class="fab fa-linkedin" aria-label="Lukas Peng LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/lukaspeng" class="fab fa-github" aria-label="Lukas Peng GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/lukas-peng/" class="fab fa-linkedin" aria-label="Lukas Peng LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/lukaspeng" class="fab fa-github" aria-label="Lukas Peng GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2024. Keegan Duffin. Purdue University.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/keeganduffin/" class="fab fa-linkedin" aria-label="Keegan Duffin LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/keeganlduffin" class="fab fa-github" aria-label="Keegan Duffin GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/keeganduffin/" class="fab fa-linkedin" aria-label="Keegan Duffin LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/keeganlduffin" class="fab fa-github" aria-label="Keegan Duffin GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2024. Dale Stager. Purdue University.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/dale-stager/" class="fab fa-linkedin" aria-label="Dale Stager LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/Landbanana" class="fab fa-github" aria-label="Dale Stager GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/dale-stager/" class="fab fa-linkedin" aria-label="Dale Stager LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/Landbanana" class="fab fa-github" aria-label="Dale Stager GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       </ul>
       </li>
       <li style="margin-bottom: 10px;">2024. Abigail Delaney. Imperial College London, MSc Student in AI and Machine Learning.
       <ul class="icons" style="display: inline; margin-left: 10px; list-style: none;">
-      <li style="display: inline;"><a href="https://www.linkedin.com/in/abby-delaney-693b4321a/" class="fab fa-linkedin" aria-label="Abigail Delaney LinkedIn Profile" target="_blank"><span class="label">LinkedIn</span></a></li>
-      <li style="display: inline;"><a href="https://github.com/abdelane" class="fab fa-github" aria-label="Abigail Delaney GitHub Profile" target="_blank"><span class="label">GitHub</span></a></li>
+      <li style="display: inline;"><a href="https://www.linkedin.com/in/abby-delaney-693b4321a/" class="fab fa-linkedin" aria-label="Abigail Delaney LinkedIn Profile" target="_blank" rel="noopener noreferrer"><span class="label">LinkedIn</span></a></li>
+      <li style="display: inline;"><a href="https://github.com/abdelane" class="fab fa-github" aria-label="Abigail Delaney GitHub Profile" target="_blank" rel="noopener noreferrer"><span class="label">GitHub</span></a></li>
       </ul>
       </li>
       </ul>

--- a/4-publications.md
+++ b/4-publications.md
@@ -16,7 +16,7 @@ banner_color: style3
    <h2>Overview</h2>
   </header>
   <p>Here is a list of our scholarly publications.</p>
-        <p>Notice that the most updated list is provided by <a href="https://scholar.google.com/citations?user=8s6SR7YAAAAJ&hl=en" target="_blank">Google Scholar</a>.</p>
+        <p>Notice that the most updated list is provided by <a href="https://scholar.google.com/citations?user=8s6SR7YAAAAJ&hl=en" target="_blank" rel="noopener noreferrer">Google Scholar</a>.</p>
   {% include publications style="apa" link=true %}
  </div>
 </section>

--- a/6-software.md
+++ b/6-software.md
@@ -30,7 +30,7 @@ banner_color: style4
    <li>Feasibility Pump (FP)</li>
   </ul>
   <ul class="actions">
-   <li><a href="https://pyomo.readthedocs.io/en/stable/explanation/solvers/mindtpy.html" class="button next" target="_blank">Get Started</a></li>
+   <li><a href="https://pyomo.readthedocs.io/en/stable/explanation/solvers/mindtpy.html" class="button next" target="_blank" rel="noopener noreferrer">Get Started</a></li>
   </ul>
  </div>
 </section>
@@ -42,7 +42,7 @@ banner_color: style4
    <h2>QUBO.jl</h2>
   </header>
   <p>
-   <a href="https://github.com/JuliaQUBO/QUBO.jl" target="_blank">QUBO.jl</a> is a Julia library for modeling and solving quadratic unconstrained binary optimization (QUBO) problems. It offers a flexible, extensible framework for QUBO formulation and is compatible with a wide range of classical and quantum solvers.
+   <a href="https://github.com/JuliaQUBO/QUBO.jl" target="_blank" rel="noopener noreferrer">QUBO.jl</a> is a Julia library for modeling and solving quadratic unconstrained binary optimization (QUBO) problems. It offers a flexible, extensible framework for QUBO formulation and is compatible with a wide range of classical and quantum solvers.
   </p>
   <p>
    QUBO.jl supports features including:
@@ -54,7 +54,7 @@ banner_color: style4
    <li>Integration with the <code>MathOptInterface</code> for solver interoperability</li>
   </ul>
   <ul class="actions">
-   <li><a href="https://github.com/JuliaQUBO/QUBO.jl" class="button next" target="_blank">View Repository</a></li>
+   <li><a href="https://github.com/JuliaQUBO/QUBO.jl" class="button next" target="_blank" rel="noopener noreferrer">View Repository</a></li>
   </ul>
  </div>
 </section>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -90,8 +90,8 @@
 			</ul>
 			<ul class="copyright">
 				<li>&copy; {{ site.title }} {{ site.subtitle }}</li>
-				<li>Design: <a href="https://html5up.net" target="_blank">HTML5 UP</a></li>
-				<li>Jekyll integration by <a href="https://github.com/andrewbanchich" target="_blank">Andrew Banchich</a> | Template adapted from <a href="https://pulsipher.info/" target="_blank">Joshua Pulsipher</a></li>
+				<li>Design: <a href="https://html5up.net" target="_blank" rel="noopener noreferrer">HTML5 UP</a></li>
+				<li>Jekyll integration by <a href="https://github.com/andrewbanchich" target="_blank" rel="noopener noreferrer">Andrew Banchich</a> | Template adapted from <a href="https://pulsipher.info/" target="_blank" rel="noopener noreferrer">Joshua Pulsipher</a></li>
 			</ul>
 		</div>
 	</footer>

--- a/index.md
+++ b/index.md
@@ -38,5 +38,5 @@ show_tile: false
 
 <p>
   This site is a mirror of our official Purdue webpage:
-  <a href="https://engineering.purdue.edu/SECQUOIA" aria-label="Visit the official Purdue SECQUOIA webpage" target="_blank">engineering.purdue.edu/SECQUOIA</a>.
+  <a href="https://engineering.purdue.edu/SECQUOIA" aria-label="Visit the official Purdue SECQUOIA webpage" target="_blank" rel="noopener noreferrer">engineering.purdue.edu/SECQUOIA</a>.
 </p>


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to links using `target="_blank"`
- apply updates across members, PI page, publications, software, footer, and home external links

## Why
Hardens external-tab behavior and aligns with best practice for `_blank` links.

Closes #149
