### PR TITLE
Scope service worker caching to same-origin static assets

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,7 @@
 ---
 ---
 const CACHE_NAME = 'secquoia-v2';
+const CACHEABLE_DESTINATIONS = new Set(['style', 'script', 'image', 'font', 'document']);
 const urlsToCache = [
   '/',
   '/assets/css/main.css',
@@ -43,8 +44,10 @@ self.addEventListener('fetch', function(event) {
   }
 
   const isSameOrigin = requestUrl.origin === self.location.origin;
-  const cacheableDestinations = ['style', 'script', 'image', 'font'];
-  const shouldCache = isSameOrigin && cacheableDestinations.includes(event.request.destination);
+  const shouldCache = isSameOrigin && CACHEABLE_DESTINATIONS.has(event.request.destination);
+  if (!shouldCache) {
+    return;
+  }
 
   event.respondWith(
     fetch(event.request)
@@ -71,7 +74,9 @@ self.addEventListener('fetch', function(event) {
       })
       .catch(function() {
         // If network fails, try cache
-        return caches.match(event.request);
+        return caches.match(event.request).then(function(cachedResponse) {
+          return cachedResponse || Response.error();
+        });
       })
   );
 });

--- a/sw.js
+++ b/sw.js
@@ -32,6 +32,20 @@ self.addEventListener('install', function(event) {
 
 // Fetch event - network first, fall back to cache
 self.addEventListener('fetch', function(event) {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const requestUrl = new URL(event.request.url);
+  const isHttpRequest = requestUrl.protocol === 'http:' || requestUrl.protocol === 'https:';
+  if (!isHttpRequest) {
+    return;
+  }
+
+  const isSameOrigin = requestUrl.origin === self.location.origin;
+  const cacheableDestinations = ['style', 'script', 'image', 'font'];
+  const shouldCache = isSameOrigin && cacheableDestinations.includes(event.request.destination);
+
   event.respondWith(
     fetch(event.request)
       .then(function(response) {
@@ -39,7 +53,7 @@ self.addEventListener('fetch', function(event) {
         const responseToCache = response.clone();
         
         // Only cache successful responses (200-299 status codes)
-        if (response.ok) {
+        if (response.ok && shouldCache) {
           // Use waitUntil to ensure cache operation completes
           event.waitUntil(
             caches.open(CACHE_NAME)


### PR DESCRIPTION
## Summary
- skip non-GET requests in service worker fetch handler
- skip non-HTTP(S) requests
- only cache same-origin static asset destinations (`style`, `script`, `image`, `font`)

## Why
Prevents broad/unbounded caching of arbitrary responses while preserving static asset caching behavior.

Closes #151
