### PR TITLE
Simplify CI markdownlint config lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,5 +169,6 @@ jobs:
       - name: Lint Markdown files
         uses: articulate/actions-markdownlint@v1
         with:
+          # The action auto-discovers .markdownlint.{yaml,yml,json} in repo root.
           files: '**/*.md'
           ignore: 'node_modules,vendor'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,5 @@ jobs:
       - name: Lint Markdown files
         uses: articulate/actions-markdownlint@v1
         with:
-          config: .markdownlint.json
           files: '**/*.md'
           ignore: 'node_modules,vendor'

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,20 +1,5 @@
 {
   "default": true,
   "MD013": false,
-  "MD033": false,
-  "MD041": false,
-  "MD001": false,
-  "MD025": false,
-  "MD034": false,
-  "MD059": false,
-  "MD003": false,
-  "MD009": false,
-  "MD010": false,
-  "MD012": false,
-  "MD022": false,
-  "MD032": false,
-  "MD036": false,
-  "MD040": false,
-  "MD046": false,
-  "MD047": false
+  "MD033": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,20 @@
 {
   "default": true,
   "MD013": false,
-  "MD033": false
+  "MD033": false,
+  "MD041": false,
+  "MD001": false,
+  "MD025": false,
+  "MD034": false,
+  "MD059": false,
+  "MD003": false,
+  "MD009": false,
+  "MD010": false,
+  "MD012": false,
+  "MD022": false,
+  "MD032": false,
+  "MD036": false,
+  "MD040": false,
+  "MD046": false,
+  "MD047": false
 }


### PR DESCRIPTION
## Summary
- remove explicit `config: .markdownlint.json` from CI markdownlint action
- allow action to use its default config lookup behavior

## Why
Makes markdownlint workflow less brittle with respect to explicit path wiring while preserving lint behavior.

Closes #152
