### PR TITLE
Add missing html lang attributes across layouts

### DIFF
--- a/_layouts/allposts.html
+++ b/_layouts/allposts.html
@@ -4,7 +4,7 @@
     html5up.net | @ajlkn
     Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
   -->
-<html>
+<html lang="en">
 
   {% include head.html %}
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html>
+<html lang="en">
 
 {% include head.html %}
 

--- a/_layouts/mdpage.html
+++ b/_layouts/mdpage.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html>
+<html lang="en">
 
 {% include head.html %}
 

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
 
   {% include head.html %}
 

--- a/_layouts/pdf.html
+++ b/_layouts/pdf.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html>
+<html lang="en">
 
 {% include head.html %}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html>
+<html lang="en">
 
 {% include head.html %}
 


### PR DESCRIPTION
## Summary
- add `lang="en"` to `<html>` in layouts missing it:
  - `_layouts/home.html`
  - `_layouts/post.html`
  - `_layouts/news.html`
  - `_layouts/allposts.html`
  - `_layouts/mdpage.html`
  - `_layouts/pdf.html`

## Why
Improves accessibility and language metadata consistency across rendered pages.

Closes #154
