### PR TITLE
Fix false-positive cdnjs preconnect link failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Check Jekyll configuration
         run: bundle exec jekyll doctor
 
+      - name: Test link checker configuration
+        run: ruby test/link_checker_preconnect_test.rb
+
       # Build the site (test build)
       - name: Test Jekyll build
         run: bundle exec jekyll build --verbose
@@ -88,7 +91,7 @@ jobs:
           set +e
           bundle exec htmlproofer ./_site \
             --checks Links \
-            --ignore-urls "/localhost/,/127.0.0.1/,/fonts.googleapis.com/,/fonts.gstatic.com/" \
+            --ignore-urls "/localhost/,/127.0.0.1/,/fonts.googleapis.com/,/fonts.gstatic.com/,/^https:\/\/cdnjs\.cloudflare\.com\/?$/" \
             --typhoeus "{\"timeout\": 30, \"connecttimeout\": 10}" \
             --hydra "{\"max_concurrency\": 10}" \
             --cache "{\"timeframe\": {\"external\": \"1d\"}}" \

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -40,7 +40,7 @@ jobs:
           set +e
           bundle exec htmlproofer ./_site \
             --checks Links \
-            --ignore-urls "/localhost/,/127.0.0.1/,/fonts.googleapis.com/,/fonts.gstatic.com/" \
+            --ignore-urls "/localhost/,/127.0.0.1/,/fonts.googleapis.com/,/fonts.gstatic.com/,/^https:\/\/cdnjs\.cloudflare\.com\/?$/" \
             --typhoeus "{\"timeout\": 30, \"connecttimeout\": 10}" \
             --hydra "{\"max_concurrency\": 10}" \
             --cache "{\"timeframe\": {\"external\": \"1d\"}}" \

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -58,7 +58,7 @@ jobs:
           set +e
           bundle exec htmlproofer ./_site \
             --checks Links \
-            --ignore-urls "/localhost/,/127.0.0.1/,/fonts.googleapis.com/,/fonts.gstatic.com/" \
+            --ignore-urls "/localhost/,/127.0.0.1/,/fonts.googleapis.com/,/fonts.gstatic.com/,/^https:\/\/cdnjs\.cloudflare\.com\/?$/" \
             --typhoeus "{\"timeout\": 30, \"connecttimeout\": 10}" \
             --hydra "{\"max_concurrency\": 10}" \
             --cache "{\"timeframe\": {\"external\": \"1d\"}}" \

--- a/test/link_checker_preconnect_test.rb
+++ b/test/link_checker_preconnect_test.rb
@@ -1,0 +1,25 @@
+repo_root = ARGV[0] ? File.expand_path(ARGV[0]) : File.expand_path("..", __dir__)
+workflow = File.read(File.join(repo_root, ".github/workflows/link-checker.yml"))
+ignore_urls = workflow[/--ignore-urls\s+"([^"]+)"/, 1]
+abort "weekly link checker has no --ignore-urls configuration" unless ignore_urls
+
+patterns = ignore_urls.split(",").map do |entry|
+  abort "invalid ignore pattern: #{entry.inspect}" unless entry.start_with?("/") && entry.end_with?("/")
+  Regexp.new(entry[1...-1])
+end
+
+origin_urls = ["https://cdnjs.cloudflare.com", "https://cdnjs.cloudflare.com/"]
+asset_url = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"
+ignored_origins = origin_urls.select { |url| patterns.any? { |pattern| pattern.match?(url) } }
+asset_ignored = patterns.any? { |pattern| pattern.match?(asset_url) }
+
+unless ignored_origins == origin_urls && !asset_ignored
+  abort <<~MESSAGE
+    Expected the weekly checker to ignore only the cdnjs preconnect origin.
+    Observed ignored origins: #{ignored_origins.inspect}
+    Observed asset ignored: #{asset_ignored}
+    Configured patterns: #{ignore_urls}
+  MESSAGE
+end
+
+puts "weekly checker ignores the cdnjs origin but still checks cdnjs assets"

--- a/test/link_checker_preconnect_test.rb
+++ b/test/link_checker_preconnect_test.rb
@@ -1,25 +1,33 @@
 repo_root = ARGV[0] ? File.expand_path(ARGV[0]) : File.expand_path("..", __dir__)
-workflow = File.read(File.join(repo_root, ".github/workflows/link-checker.yml"))
-ignore_urls = workflow[/--ignore-urls\s+"([^"]+)"/, 1]
-abort "weekly link checker has no --ignore-urls configuration" unless ignore_urls
-
-patterns = ignore_urls.split(",").map do |entry|
-  abort "invalid ignore pattern: #{entry.inspect}" unless entry.start_with?("/") && entry.end_with?("/")
-  Regexp.new(entry[1...-1])
-end
-
+workflow_paths = [
+  ".github/workflows/link-checker.yml",
+  ".github/workflows/ci.yml",
+  ".github/workflows/preview.yml"
+]
 origin_urls = ["https://cdnjs.cloudflare.com", "https://cdnjs.cloudflare.com/"]
 asset_url = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"
-ignored_origins = origin_urls.select { |url| patterns.any? { |pattern| pattern.match?(url) } }
-asset_ignored = patterns.any? { |pattern| pattern.match?(asset_url) }
 
-unless ignored_origins == origin_urls && !asset_ignored
-  abort <<~MESSAGE
-    Expected the weekly checker to ignore only the cdnjs preconnect origin.
-    Observed ignored origins: #{ignored_origins.inspect}
-    Observed asset ignored: #{asset_ignored}
-    Configured patterns: #{ignore_urls}
-  MESSAGE
+workflow_paths.each do |workflow_path|
+  workflow = File.read(File.join(repo_root, workflow_path))
+  ignore_urls = workflow[/--ignore-urls\s+"([^"]+)"/, 1]
+  abort "#{workflow_path} has no --ignore-urls configuration" unless ignore_urls
+
+  patterns = ignore_urls.split(",").map do |entry|
+    abort "invalid ignore pattern in #{workflow_path}: #{entry.inspect}" unless entry.start_with?("/") && entry.end_with?("/")
+    Regexp.new(entry[1...-1])
+  end
+
+  ignored_origins = origin_urls.select { |url| patterns.any? { |pattern| pattern.match?(url) } }
+  asset_ignored = patterns.any? { |pattern| pattern.match?(asset_url) }
+
+  unless ignored_origins == origin_urls && !asset_ignored
+    abort <<~MESSAGE
+      Expected #{workflow_path} to ignore only the cdnjs preconnect origin.
+      Observed ignored origins: #{ignored_origins.inspect}
+      Observed asset ignored: #{asset_ignored}
+      Configured patterns: #{ignore_urls}
+    MESSAGE
+  end
 end
 
-puts "weekly checker ignores the cdnjs origin but still checks cdnjs assets"
+puts "external link checkers ignore the cdnjs origin but still check cdnjs assets"


### PR DESCRIPTION
## Summary

- exclude only the cdnjs preconnect origin from scheduled, PR, and preview external-link audits
- keep concrete cdnjs asset URLs subject to HTML-Proofer checks
- run the regression guard in CI and cover all three external-link workflows
- retain the test recorded in the [triage evidence](https://github.com/SECQUOIA/SECQUOIA.github.io/issues/183#issuecomment-5022555420)

## Acceptance criteria

- [x] External-link workflows exclude the exact cdnjs origin with or without a trailing slash.
- [x] Real cdnjs asset URLs remain subject to external-link validation.
- [x] CI executes the regression guard.
- [x] Existing site build and link/image validation pass.

## Validation

- `ruby test/link_checker_preconnect_test.rb` (red on the missing sibling configurations, green after the fixes)
- `ruby -c test/link_checker_preconnect_test.rb`
- `actionlint`
- `docker run --rm --user 1000:1000 -v "$PWD:/app" -w /app secquoia-website bundle exec jekyll build`
- internal HTML-Proofer checks for links, images, and scripts
- the PR-time external HTML-Proofer command (268 external links checked successfully)
- `bash scripts/check_referenced_images.sh`
- `git diff --cached --check`

## Branch Hygiene

- Base: `main` at `b2fa01a88dd8dbc5fe0c6523b32d82b5cceae533`
- Source: `fix/issue-183-cdnjs-preconnect-check`, created directly from fresh `origin/main`
- Stacked: no
- Prerequisites: none; open PR #182 has no changed-file overlap

Closes #183
